### PR TITLE
Allow .coffee script aggregates & sagas

### DIFF
--- a/lib/loaders/aggregateLoader.js
+++ b/lib/loaders/aggregateLoader.js
@@ -50,7 +50,7 @@ module.exports = {
             function(businessRules, callback) {
                 utils.path.dive(aggregatesPath, function(err, file) {
                     var aggregate = require(file);
-                    var name = path.basename(file, '.js');
+                    var name = path.basename(file, path.extname(file));
 
                     aggregate.prototype.businessRules = businessRules[name];
 

--- a/lib/loaders/sagaLoader.js
+++ b/lib/loaders/sagaLoader.js
@@ -15,7 +15,7 @@ module.exports = sagaLoader = {
 
         utils.path.dive(p, function(err, file) {
             var saga = require(file);
-            var name = path.basename(file, '.js');
+            var name = path.basename(file, path.extname(file));
 
             sagas[name] = saga;
         }, function() {


### PR DESCRIPTION
The current Aggregate and Saga loaders only allow `.js` this patch just strips the current file extensions. 
Meaning that for example `.coffee` files are also named correctly.
