### PR TITLE
Correctly resolve revision number for some commands

### DIFF
--- a/lib/definitions/aggregate.js
+++ b/lib/definitions/aggregate.js
@@ -117,13 +117,13 @@ function applyHelper (aggregate, aggregateModel, cmd) {
     var aggName, ctxName;
 
     if (!!aggregate.definitions.event.aggregate && !!aggregate.definitions.command.aggregate) {
-      aggName = dotty.get(cmd, aggregate.definitions.command.aggregate);
-      dotty.put(evt, aggregate.definitions.event.aggregate, aggName || aggregate.name);
+      aggName = dotty.get(cmd, aggregate.definitions.command.aggregate) || aggregate.name;
+      dotty.put(evt, aggregate.definitions.event.aggregate, aggName);
     }
 
     if (!!aggregate.definitions.event.context && !!aggregate.definitions.command.context) {
-      ctxName = dotty.get(cmd, aggregate.definitions.command.context);
-      dotty.put(evt, aggregate.definitions.event.context, ctxName || aggregate.context.name);
+      ctxName = dotty.get(cmd, aggregate.definitions.command.context) || aggregate.context.name;
+      dotty.put(evt, aggregate.definitions.event.context, ctxName);
     }
 
     var aggregateId;


### PR DESCRIPTION
Set aggregate and context names correctly in var streamInfo when they are not defined in command.
Otherwise may not resolve revision number correctly.