### PR TITLE
Added commandAwareAggregateIdGenerator and tests

### DIFF
--- a/lib/defaultCommandHandler.js
+++ b/lib/defaultCommandHandler.js
@@ -1028,7 +1028,7 @@ _.extend(DefaultCommandHandler.prototype, {
 
     debug('no aggregateId in command, so generate a new one');
 
-    this.getNewAggregateId(function (err, id) {
+    this.getNewAggregateId(cmd, function (err, id) {
       if (err) {
         debug(err);
         return callback(err);
@@ -1045,8 +1045,8 @@ _.extend(DefaultCommandHandler.prototype, {
    */
   aggregateIdGenerator: function (fn) {
     if (fn.length === 0) {
-      fn = _.wrap(fn, function(func, callback) {
-        callback(null, func());
+      fn = _.wrap(fn, function(func, cmd, callback) {
+        callback(null, cmd, func());
       });
     }
 
@@ -1057,18 +1057,25 @@ _.extend(DefaultCommandHandler.prototype, {
 
   /**
    * IdGenerator function for aggregate id.
+   * @param {Object}   cmd      The passed command
    * @param {Function} callback The function, that will be called when this action is completed.
    *                            `function(err, newId){}`
    */
-  getNewAggregateId: function (callback) {
-    var getNewIdFn = this.eventStore.getNewId.bind(this.eventStore);
+  getNewAggregateId: function (cmd, callback) {
+    var getNewIdFn; // = this.eventStore.getNewId.bind(this.eventStore);
     if (this.aggregate && this.aggregate.getNewAggregateId) {
       getNewIdFn = this.aggregate.getNewAggregateId.bind(this.aggregate);
     } else if (this.getNewAggregateIdFn) {
       getNewIdFn = this.getNewAggregateIdFn.bind(this);
+    } else {
+      var eventstore = this.eventStore;
+      getNewIdFn = _.wrap( this.eventStore.getNewId, function(func, cmd, callback){
+        func(callback).bind(eventstore);
+      });
     }
 
-    getNewIdFn(callback);
+
+    getNewIdFn(cmd, callback);
   }
 
 });

--- a/lib/defaultCommandHandler.js
+++ b/lib/defaultCommandHandler.js
@@ -1045,35 +1045,33 @@ _.extend(DefaultCommandHandler.prototype, {
    */
   aggregateIdGenerator: function (fn) {
     if (fn.length === 0) {
-      fn = _.wrap(fn, function(func, cmd, callback) {
-        callback(null, cmd, func());
+      fn = _.wrap(fn, function(func, callback) {
+        callback(null, func());
       });
     }
 
-    this.getNewAggregateIdFn = fn;
+    this.getNewAggregateIdFn = function(cmd, callback){ fn(callback) };
 
     return this;
   },
 
   /**
    * IdGenerator function for aggregate id.
-   * @param {Object}   cmd      The passed command
    * @param {Function} callback The function, that will be called when this action is completed.
    *                            `function(err, newId){}`
    */
   getNewAggregateId: function (cmd, callback) {
-    var getNewIdFn; // = this.eventStore.getNewId.bind(this.eventStore);
+    var getNewIdFn;
     if (this.aggregate && this.aggregate.getNewAggregateId) {
       getNewIdFn = this.aggregate.getNewAggregateId.bind(this.aggregate);
     } else if (this.getNewAggregateIdFn) {
       getNewIdFn = this.getNewAggregateIdFn.bind(this);
     } else {
-      var eventstore = this.eventStore;
-      getNewIdFn = _.wrap( this.eventStore.getNewId, function(func, cmd, callback){
-        func(callback).bind(eventstore);
-      });
+      var es = this.eventStore;
+      getNewIdFn =  function(cmd, callback){ 
+        es.getNewId(callback).bind(es); 
+      };
     }
-
 
     getNewIdFn(cmd, callback);
   }

--- a/lib/definitions/aggregate.js
+++ b/lib/definitions/aggregate.js
@@ -891,6 +891,25 @@ _.extend(Aggregate.prototype, {
       });
     }
 
+    this.getNewAggregateId = function(cmd, callback){
+      fn(callback);
+    }
+
+    return this;
+  },
+
+  /**
+   * Inject command aware idGenerator function for aggregate id.
+   * @param   {Function}  fn The function to be injected. func(cmd, callback?)
+   * @returns {Aggregate}    to be able to chain...
+   */
+  defineCommandAwareAggregateIdGenerator: function (fn) {
+    if (fn.length < 2) {
+      fn = _.wrap(fn, function(func, cmd, callback) {
+        callback(null, func(cmd));
+      });
+    }
+
     this.getNewAggregateId = fn;
 
     return this;

--- a/lib/definitions/commandHandler.js
+++ b/lib/definitions/commandHandler.js
@@ -85,7 +85,7 @@ _.extend(CommandHandler.prototype, {
 
     debug('no aggregateId in command, so generate a new one');
 
-    this.getNewAggregateId(function (err, id) {
+    this.getNewAggregateId(cmd, function (err, id) {
       if (err) {
         debug(err);
         return callback(err);

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -242,11 +242,13 @@ _.extend(Domain.prototype, {
     }
 
     if (fn.length === 1) {
-      this.getNewAggregateId = fn;
+      this.getNewAggregateId = function(cmd, callback) { 
+        fn(callback);
+      }
       return this;
     }
 
-    this.getNewAggregateId = function (callback) {
+    this.getNewAggregateId = function (cmd, callback) {
       callback(null, fn());
     };
 

--- a/test/unit/defaultCommandHandlerTest.js
+++ b/test/unit/defaultCommandHandlerTest.js
@@ -997,7 +997,7 @@ describe('defaultCommandHandler', function () {
             });
 
             cmdHnd.useAggregate({
-              getNewAggregateId: function ({}, clb) {
+              getNewAggregateId: function (cmd, clb) {
                 clb(null, 'newIdFromAggregate');
               }
             });

--- a/test/unit/defaultCommandHandlerTest.js
+++ b/test/unit/defaultCommandHandlerTest.js
@@ -997,7 +997,7 @@ describe('defaultCommandHandler', function () {
             });
 
             cmdHnd.useAggregate({
-              getNewAggregateId: function (clb) {
+              getNewAggregateId: function ({}, clb) {
                 clb(null, 'newIdFromAggregate');
               }
             });

--- a/test/unit/definitions/aggregateTest.js
+++ b/test/unit/definitions/aggregateTest.js
@@ -35,6 +35,7 @@ describe('aggregate definition', function () {
 
       expect(aggr.idGenerator).to.be.a('function');
       expect(aggr.defineAggregateIdGenerator).to.be.a('function');
+      expect(aggr.defineCommandAwareAggregateIdGenerator).to.be.a('function');
       expect(aggr.defineContext).to.be.a('function');
       expect(aggr.addCommand).to.be.a('function');
       expect(aggr.addEvent).to.be.a('function');
@@ -205,7 +206,7 @@ describe('aggregate definition', function () {
             return id;
           });
 
-          aggr.getNewAggregateId(function (err, id) {
+          aggr.getNewAggregateId({}, function (err, id) {
             expect(id).to.be.a('string');
             done();
           });
@@ -214,7 +215,7 @@ describe('aggregate definition', function () {
 
       });
 
-      describe('in an synchronous way', function() {
+      describe('in an asynchronous way', function() {
 
         it('it should be taken as it is', function(done) {
 
@@ -225,7 +226,7 @@ describe('aggregate definition', function () {
             }, 10);
           });
 
-          aggr.getNewAggregateId(function (err, id) {
+          aggr.getNewAggregateId({}, function (err, id) {
             expect(id).to.be.a('string');
             done();
           });
@@ -235,6 +236,56 @@ describe('aggregate definition', function () {
       });
 
     });
+
+    describe('defining an command aware id generator function for aggregate id', function() {
+
+      var aggr;
+
+      beforeEach(function () {
+        aggr = api.defineAggregate();
+        aggr.getNewAggregateId = null;
+      });
+
+      describe('in a synchronous way', function() {
+
+        it('it should be transformed internally to an asynchronous way', function(done) {
+
+          aggr.defineCommandAwareAggregateIdGenerator(function (command) {
+            var id = require('uuid').v4().toString();
+            return id;
+          });
+
+          aggr.getNewAggregateId({}, function (err, id) {
+            expect(id).to.be.a('string');
+            done();
+          });
+
+        });
+
+      });
+
+      describe('in an asynchronous way', function() {
+
+        it('it should be taken as it is', function(done) {
+
+          aggr.defineCommandAwareAggregateIdGenerator(function (command, callback) {
+            setTimeout(function () {
+              var id = require('uuid').v4().toString();
+              callback(null, id);
+            }, 10);
+          });
+
+          aggr.getNewAggregateId({}, function (err, id) {
+            expect(id).to.be.a('string');
+            done();
+          });
+
+        });
+
+      });
+
+    });
+
 
     describe('calling defineContext', function () {
 

--- a/test/unit/domainTest.js
+++ b/test/unit/domainTest.js
@@ -239,7 +239,7 @@ describe('domain', function () {
             return id;
           });
 
-          domain.getNewAggregateId(function (err, id) {
+          domain.getNewAggregateId({}, function (err, id) {
             expect(id).to.be.a('string');
             done();
           });
@@ -259,7 +259,7 @@ describe('domain', function () {
             }, 10);
           });
 
-          domain.getNewAggregateId(function (err, id) {
+          domain.getNewAggregateId({}, function (err, id) {
             expect(id).to.be.a('string');
             done();
           });


### PR DESCRIPTION
As the command (meta)data may be useful when generating id in some situation ( example order id, that some includes customer id in it ), i wanted to pass the command as a parameter to the defined generator function ( on the aggregate level ).

As this is a breaking change and for backwards compatibility I've added this option under a new definer ( defineCommandAwareAggregateIdGenerator ) on the aggregate level, which, exactly as the other one, can work both synchronously or asynchronously.

I've also added the needed tests to the definition tests. 