### PR TITLE
Fix indentation of code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,19 +737,19 @@ After the initialization you can request the domain information:
 	    callback(null, id);
 	  }, 50);
 	})
-  // optionally, define idGenerator function for new aggregate ids that are command aware
-  // if you define it that way, the normal defineAggregateIdGenerator function will be replaced
-  // sync
-  .defineCommandAwareAggregateIdGenerator(function (cmd) {
-    return cmd.id + require('uuid').v4().toString();
-  });
-  // or async
-  .defineCommandAwareAggregateIdGenerator(function (cmd, callback) {
-    setTimeout(function () {
-      var id = cmd.id + require('uuid').v4().toString();
-      callback(null, id);
-    }, 50);
-  });
+    // optionally, define idGenerator function for new aggregate ids that are command aware
+    // if you define it that way, the normal defineAggregateIdGenerator function will be replaced
+    // sync
+  	.defineCommandAwareAggregateIdGenerator(function (cmd) {
+  	  return cmd.id + require('uuid').v4().toString();
+  	});
+  	// or async
+  	.defineCommandAwareAggregateIdGenerator(function (cmd, callback) {
+  	  setTimeout(function () {
+  	    var id = cmd.id + require('uuid').v4().toString();
+  	    callback(null, id);
+  	  }, 50);
+  	});
 
 
 ## Command validation


### PR DESCRIPTION
Small change. The markdown is now correctly rendered in github.