### PR TITLE
Use of node loader extensions for valid file types of parsing definition sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,11 @@ It can be very useful as domain component if you work with (d)ddd, cqrs, eventde
 			prefix: 'domain_aggregate_lock',            // optional
 			timeout: 10000                              // optional
 			// password: 'secret'                          // optional
-	  }
+	  },
+	  
+	  // optional, default false
+	  // resolves valid file types from loader extensions instead of default values while parsing definition files
+	  useLoaderExtensions: true
 	});
 
 ## Using factory methods for event store or / and aggregate lock in domain definition

--- a/lib/domain.js
+++ b/lib/domain.js
@@ -114,6 +114,8 @@ function Domain(options) {
 
   options.snapshotThreshold = options.snapshotThreshold || 100;
 
+  options.useLoaderExtensions = options.useLoaderExtensions || false
+
   this.eventStore = createEventStore(options.eventStore);
 
   this.aggregateLock = createAggregateLock(options.aggregateLock);
@@ -378,7 +380,7 @@ _.extend(Domain.prototype, {
       // load domain files...
       function (callback) {
         debug('load domain files..');
-        structureLoader(self.options.domainPath, self.validatorExtension, function (err, tree, warns) {
+        structureLoader(self.options.domainPath, self.validatorExtension, self.options.useLoaderExtensions, function (err, tree, warns) {
           if (err) {
             return callback(err);
           }

--- a/lib/structure/structureLoader.js
+++ b/lib/structure/structureLoader.js
@@ -18,7 +18,7 @@ function isSchema (item) {
 }
 
 function isContext (item) {
-  if (item.fileType !== 'js') {
+  if (item.fileType === 'json') {
     return false;
   }
 
@@ -26,7 +26,7 @@ function isContext (item) {
 }
 
 function isAggregate (item) {
-  if (item.fileType !== 'js') {
+  if (item.fileType === 'json') {
     return false;
   }
 
@@ -34,7 +34,7 @@ function isAggregate (item) {
 }
 
 function isCommand (item) {
-  if (item.fileType !== 'js') {
+  if (item.fileType === 'json') {
     return false;
   }
 
@@ -42,7 +42,7 @@ function isCommand (item) {
 }
 
 function isEvent (item) {
-  if (item.fileType !== 'js') {
+  if (item.fileType === 'json') {
     return false;
   }
 
@@ -50,7 +50,7 @@ function isEvent (item) {
 }
 
 function isPreCondition (item) {
-  if (item.fileType !== 'js') {
+  if (item.fileType === 'json') {
     return false;
   }
 
@@ -58,7 +58,7 @@ function isPreCondition (item) {
 }
 
 function isPreLoadCondition (item) {
-  if (item.fileType !== 'js') {
+  if (item.fileType === 'json') {
     return false;
   }
 
@@ -66,7 +66,7 @@ function isPreLoadCondition (item) {
 }
 
 function isBusinessRule (item) {
-  if (item.fileType !== 'js') {
+  if (item.fileType === 'json') {
     return false;
   }
 
@@ -74,7 +74,7 @@ function isBusinessRule (item) {
 }
 
 function isCommandHandler (item) {
-  if (item.fileType !== 'js') {
+  if (item.fileType === 'json') {
     return false;
   }
 
@@ -226,8 +226,8 @@ function scan (items) {
   return res;
 }
 
-function analyze (dir, callback) {
-  structureParser(dir, function (items) {
+function analyze (dir, useLoaderExtensions, callback) {
+  structureParser(dir, useLoaderExtensions, function (items) {
     return _.filter(items, function (i) {
       return isSchema(i) || isContext(i) || isAggregate(i) || isCommand(i) || isEvent(i) || isBusinessRule(i) || isPreCondition(i) || isPreLoadCondition(i) || isCommandHandler(i);
     });
@@ -550,8 +550,8 @@ function reorder (obj, validatorExtension) {
   return ordered;
 }
 
-function load (dir, validatorExtension, callback) {
-  analyze(dir, function (err, dividedByTypes, warns) {
+function load (dir, validatorExtension, useLoaderExtensions, callback) {
+  analyze(dir, useLoaderExtensions, function (err, dividedByTypes, warns) {
     if (err) {
       return callback(err);
     }

--- a/lib/structure/structureParser.js
+++ b/lib/structure/structureParser.js
@@ -136,12 +136,21 @@ function pathToJson (root, paths, addWarning) {
   return res;
 }
 
-function parse (dir, filter, callback) {
+function parse (dir, useLoaderExtensions, filter, callback) {
   if (!callback) {
     callback = filter;
     filter = function (r) {
       return r;
     };
+  }
+
+  if (useLoaderExtensions) {
+    validFileTypes = Object.keys(require.extensions)
+      .map(function (ext) {
+        return ext.substr(1);
+      });
+    
+    debug('Using valid file types from loader extensions');
   }
 
   dir = path.resolve(dir);


### PR DESCRIPTION
Hello, @adrai!

Here is a proposed solution regarding of initializing domain files in other than `*.js` file extensions. For resolving valid file types here being used **node loader extensions** by control of domain init param `useLoaderExtensions` which is a boolean. On option default value it uses default valid file types.

Issue #89
