### PR TITLE
Do not set revision when persistence is disabled

### DIFF
--- a/lib/definitions/aggregate.js
+++ b/lib/definitions/aggregate.js
@@ -144,9 +144,11 @@ function applyHelper (aggregate, aggregateModel, cmd) {
       aggregate: aggName,// || aggregate.name,
       aggregateId: aggregateId || aggregateModel.id
     };
-    var revision = aggregateModel.getRevision(streamInfo) + 1;
-    aggregateModel.setRevision(streamInfo, revision);
-    dotty.put(evt, aggregate.definitions.event.revision, revision);
+    if (!aggregate.disablePersistence) {
+      var revision = aggregateModel.getRevision(streamInfo) + 1;
+      aggregateModel.setRevision(streamInfo, revision);
+      dotty.put(evt, aggregate.definitions.event.revision, revision);
+    }
 
     aggregateModel.addUncommittedEvent(evt);
 

--- a/test/unit/definitions/aggregateTest.js
+++ b/test/unit/definitions/aggregateTest.js
@@ -1437,8 +1437,34 @@ describe('aggregate definition', function () {
 
         });
 
-      });
+        it('it should not set revision when persistance is disabled', function () {
 
+          var evts = [{ evtName: 'nonPersistant'}];
+          var rev = null;
+          var aggModel = {
+            set: function () {},
+            setRevision: function (info, r) { rev = r;},
+            toJSON: function () { return 'json'; }
+          };
+
+          var aggr = api.defineAggregate({
+            skipHistory: true,
+            applyLastEvent: true,
+            disablePersistence: true
+          });
+
+          aggr.apply = function (evts, aggregateModel) { // mock
+            expect(events).to.eql(evts);
+            expect(aggregateModel).to.eql(aggModel);
+            expect(aggregateModel).to.eql(aggModel);
+          };
+
+          expect(rev).to.eql(null);
+
+        });
+
+    });
+    
       describe('passing a snapshot and some events', function () {
 
         it('it should actualize the aggregateModel correctly', function () {


### PR DESCRIPTION
Setting a revision on events from aggregates with disabled persistence is unneeded and introduces unwanted behaviour when those pass trough revision guard stores in other services.

By omitting the revision property on those events ( as they have none ) the revision guard store is not handling those and they work as intended.
