### PR TITLE
Add externallyLoaded option to context, and load those separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,18 @@ After the initialization you can request the domain information:
 	  name: 'hr'
 	});
 
+### Externally loaded context ( self-loaded ) 
+
+	A special option to define a context with all its aggregates, commands, events and rules exists by adding the externallyLoaded option to the context :
+
+	module.exports = require('cqrs-domain').defineContext({
+	  // optional, default is the directory name
+	  name: 'hr',
+		externallyLoaded: true
+	});
+
+	When doing so the context will be added 'as-is' to the domain, this means it won't go trough the normal tree loading and parsing process.
+	This option is aimed mainly at plugin developers, as it leaves the responsibility of structuring the domain right in the hand of the one defining the context ( most-probably a plug-in ).
 
 ## Aggregate
 

--- a/lib/bumper/databases/redis.js
+++ b/lib/bumper/databases/redis.js
@@ -136,7 +136,7 @@ _.extend(Redis.prototype, {
     this.stopHeartbeat();
 
     if (this.client) {
-      this.client.end(true);
+      this.client.quit();
     }
     this.emit('disconnect');
     if (callback) callback(null, this);

--- a/lib/bumper/databases/redis.js
+++ b/lib/bumper/databases/redis.js
@@ -136,7 +136,7 @@ _.extend(Redis.prototype, {
     this.stopHeartbeat();
 
     if (this.client) {
-      this.client.quit();
+      this.client.end(true);
     }
     this.emit('disconnect');
     if (callback) callback(null, this);

--- a/lib/definitions/context.js
+++ b/lib/definitions/context.js
@@ -14,6 +14,8 @@ function Context (meta) {
 
   meta = meta || {};
 
+  this.externallyLoaded = meta.externallyLoaded || false;
+
   this.aggregates = [];
 }
 

--- a/lib/lock/databases/redis.js
+++ b/lib/lock/databases/redis.js
@@ -13,7 +13,7 @@ function Redis(options) {
     prefix: 'aggregatelock',
     retry_strategy: function (options) {
       return undefined;
-    }//,
+    }
     // heartbeat: 60 * 1000
   };
 
@@ -135,7 +135,7 @@ _.extend(Redis.prototype, {
     this.stopHeartbeat();
 
     if (this.client) {
-      this.client.end(true);
+      this.client.quit();
     }
     this.emit('disconnect');
     if (callback) callback(null, this);

--- a/lib/lock/databases/redis.js
+++ b/lib/lock/databases/redis.js
@@ -135,7 +135,7 @@ _.extend(Redis.prototype, {
     this.stopHeartbeat();
 
     if (this.client) {
-      this.client.quit();
+      this.client.end(true);
     }
     this.emit('disconnect');
     if (callback) callback(null, this);

--- a/lib/structure/structureLoader.js
+++ b/lib/structure/structureLoader.js
@@ -274,11 +274,22 @@ function analyze (dir, useLoaderExtensions, callback) {
   });
 }
 
+function reorderExternallyLoadedContexts (obj, ordered) {
+  obj.contexts.forEach(function (ctxItem) {
+    if (!ctxItem.value.externallyLoaded)
+      return;
+      ordered[ctxItem.name] = ctxItem.value;
+  });
+}
+
 function reorderAggregates (obj, ordered) {
   var generalContext = new Context({ name: '_general' });
 
   obj.aggregates.forEach(function (aggItem) {
     var foundCtx = _.find(obj.contexts, function (ctx) {
+      if (ctx.value.externallyLoaded) {
+        return false;
+      }
       if (aggItem.dottiedBase.indexOf('.') >= 0) {
         return aggItem.dottiedBase.indexOf(ctx.dottiedBase + '.') === 0;
       } else {
@@ -288,6 +299,9 @@ function reorderAggregates (obj, ordered) {
 
     if (!foundCtx) {
       foundCtx = _.find(obj.contexts, function (ctx) {
+        if (ctx.value.externallyLoaded) {
+          return false;
+        }
         return ctx.dottiedBase === '';
       });
     }


### PR DESCRIPTION
This update adds an externallyLoaded option to the context definition. Basically, this means that the user ( or more likely a library ) provides the structureLoader with an already defined context object which can be used directly ( a context object to which aggregates are added, to which commands are added and so on ).

This allows writing alternative/additional loaders, who can output the result in ready to use for this library. This will allow requests [like this one](https://github.com/adrai/node-cqrs-domain/issues/117) and [this one](https://github.com/adrai/node-cqrs-domain/issues/74) achieved fairly easy according to other logic/structure without breaking the existing logic/definitions.

This whole is done as are in a process of writing an on-top addition/library allowing a one-file aggregate definitions similar to other CQRS implementations.