### PR TITLE
Schema validation rules structure loader bug fix

### DIFF
--- a/lib/structure/structureLoader.js
+++ b/lib/structure/structureLoader.js
@@ -480,7 +480,11 @@ function reorderValidationRules (obj, ordered, validatorExtension) {
     }
 
     var foundAggr = _.find(obj.aggregates, function (aggr) {
-      return schemaItem.dottiedBase.indexOf(aggr.dottiedBase) === 0;
+      if (schemaItem.dottiedBase.indexOf('.') >= 0) {
+        return schemaItem.dottiedBase.indexOf(aggr.dottiedBase + '.') === 0;
+      } else {
+        return schemaItem.dottiedBase === aggr.dottiedBase;
+      }
     });
 
     if (foundAggr) {


### PR DESCRIPTION
When using json schema validation for commands with the default structure loader and multiple aggregates, if one of the aggregate names is actually a part of another aggregate name - for example "item" and "itemGroup", the `foundAggr` would return true on "item" for both of them which results in missing validations.

The fix is the same as other checks in the structureLoader.js file.