### PR TITLE
Adding SRV support for MongoDB

### DIFF
--- a/lib/bumper/databases/mongodb.js
+++ b/lib/bumper/databases/mongodb.js
@@ -14,6 +14,7 @@ function Mongo(options) {
     port: 27017,
     dbName: 'domain',
     collectionName: 'commandbumper',
+    protocol: 'mongodb://',
     // heartbeat: 60 * 1000
     ttl:  1000 * 60 * 60 * 1 // 1 hour
   };
@@ -56,15 +57,23 @@ _.extend(Mongo.prototype, {
         ? options.servers
         : [{host: options.host, port: options.port}];
 
-      var memberString = _(members).map(function(m) { return m.host + ':' + m.port; });
+      var memberString = _(members).map(function(m) {
+        if (options.protocol === 'mongodb+srv://') {
+          return m.host;
+        }
+
+        return m.host + ':' + m.port;
+      });
+
       var authString = options.username && options.password
         ? options.username + ':' + options.password + '@'
         : '';
+
       var optionsString = options.authSource
         ? '?authSource=' + options.authSource
         : '';
 
-      connectionUrl = 'mongodb://' + authString + memberString + '/' + options.dbName + optionsString;
+      connectionUrl = options.protocol + authString + memberString + '/' + options.dbName + optionsString;
     }
 
     var client;

--- a/lib/lock/databases/mongodb.js
+++ b/lib/lock/databases/mongodb.js
@@ -13,7 +13,8 @@ function Mongo(options) {
     host: 'localhost',
     port: 27017,
     dbName: 'domain',
-    collectionName: 'aggregatelock'//,
+    collectionName: 'aggregatelock',
+    protocol: 'mongodb://'
     // heartbeat: 60 * 1000
   };
 
@@ -55,17 +56,25 @@ _.extend(Mongo.prototype, {
         ? options.servers
         : [{host: options.host, port: options.port}];
 
-      var memberString = _(members).map(function(m) { return m.host + ':' + m.port; });
+      var memberString = _(members).map(function(m) {
+        if (options.protocol === 'mongodb+srv://') {
+          return m.host;
+        }
+
+        return m.host + ':' + m.port;
+      });
+
       var authString = options.username && options.password
         ? options.username + ':' + options.password + '@'
         : '';
+
       var optionsString = options.authSource
         ? '?authSource=' + options.authSource
         : '';
 
-      connectionUrl = 'mongodb://' + authString + memberString + '/' + options.dbName + optionsString;
+      connectionUrl = options.protocol + authString + memberString + '/' + options.dbName + optionsString;
     }
-
+    
     var client;
 
     if (mongo.MongoClient.length === 2) {


### PR DESCRIPTION
This will enable MongoDB Atlas mongodb+srv:// URLs to be used without specifying the single servers, therefore being able to change and scale any MongoDB cluster without affecting any client.